### PR TITLE
Update README.md to include TEST_PROJECT_ID

### DIFF
--- a/cmdline-pull/README.md
+++ b/cmdline-pull/README.md
@@ -27,6 +27,9 @@ Install Maven and Java7.
   - GOOGLE_APPLICATION_CREDENTIALS: the file path to the downloaded JSON file.
 
 ## Build the application
+- Set the following environment variable.
+  - TEST_PROJECT_ID: the ID of your Google Cloud project.
+  - note: the above environment variable is only required during the build phase.
 
 ```
 $ mvn package


### PR DESCRIPTION
TEST_PROJECT_ID is required during the build phase, otherwise the PubSub integration test in cmdline-pull will fail.