### PR TITLE
Use /_ah/push-handlers/ prefix for the push endpoint.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
           openssl aes-256-cbc -K $encrypted_da6c5a15484c_key -iv $encrypted_da6c5a15484c_iv -in service-account.json.enc -out service-account.json -d;
       fi
     - gcloud -q components update gae-java gae-python
+    - gcloud -q components update --version 104.0.0
     - if [ -a service-account.json ]; then
           gcloud auth activate-service-account --key-file service-account.json;
       fi

--- a/appengine-push/src/main/java/com/google/cloud/pubsub/client/demos/appengine/util/PubsubUtils.java
+++ b/appengine-push/src/main/java/com/google/cloud/pubsub/client/demos/appengine/util/PubsubUtils.java
@@ -113,7 +113,8 @@ public final class PubsubUtils {
         String subscriptionUniqueToken = System.getProperty(
                 Constants.BASE_PACKAGE + ".subscriptionUniqueToken");
 
-        return "https://" + getProjectId() + ".appspot.com/receive_message"
+        return "https://" + getProjectId()
+            + ".appspot.com/_ah/push-handlers/receive_message"
             + "?token=" + subscriptionUniqueToken;
     }
 

--- a/appengine-push/src/main/webapp/WEB-INF/web.xml
+++ b/appengine-push/src/main/webapp/WEB-INF/web.xml
@@ -42,8 +42,17 @@
   </servlet>
   <servlet-mapping>
     <servlet-name>Receive_Servlet</servlet-name>
-    <url-pattern>/receive_message</url-pattern>
+    <url-pattern>/_ah/push-handlers/receive_message</url-pattern>
   </servlet-mapping>
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>push-handlers</web-resource-name>
+      <url-pattern>/_ah/push-handlers/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>admin</role-name>
+    </auth-constraint>
+  </security-constraint>
   <welcome-file-list>
     <welcome-file>init_servlet</welcome-file>
   </welcome-file-list>

--- a/appengine-push/src/test/java/com/google/cloud/pubsub/client/demos/appengine/IntegrationTest.java
+++ b/appengine-push/src/test/java/com/google/cloud/pubsub/client/demos/appengine/IntegrationTest.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -104,6 +105,29 @@ public class IntegrationTest {
         return response.toString();
     }
 
+    @Test
+    public void testPushHandlerIsProtected() throws Exception {
+        String url = getAppBaseURL() + "_ah/push-handlers/receive_message";
+        URL obj = new URL(url);
+        HttpsURLConnection con = (HttpsURLConnection) obj.openConnection();
+        String urlParams = "p1=a";
+        byte[] postData = urlParams.getBytes( StandardCharsets.UTF_8 );
+        con.setInstanceFollowRedirects(false);
+        con.setRequestMethod("POST");
+        con.setDoOutput(true);
+        con.setRequestProperty(
+                "Content-Length", Integer.toString(postData.length));
+        con.setRequestProperty(
+                "Content-Type", "application/x-www-form-urlencoded");
+        try(DataOutputStream wr = new DataOutputStream(
+                con.getOutputStream())) {
+            wr.write(postData);
+            wr.flush();
+        }
+        int responseCode = con.getResponseCode();
+        assertEquals(302, responseCode);
+    }
+    
     @Test
     public void testSendMessage() throws Exception {
         String url = getAppBaseURL() + "send_message";


### PR DESCRIPTION
/_ah/push-handlers is now protected as admin-required for public, but it's accessible from the Cloud Pub/Sub push service.